### PR TITLE
fix: filtered larger containers having only 18 slots

### DIFF
--- a/lib/lib.lua
+++ b/lib/lib.lua
@@ -316,8 +316,6 @@ function ei_containers_lib.make_container(size, slots, typus, animation)
     if typus then
         if typus == "filter" then
             container.inventory_type = "with_filters_and_bar"
-            -- also only 18 slots
-            container.inventory_size = 18
         end
         -- TODO add animations
 

--- a/prototypes/containers.lua
+++ b/prototypes/containers.lua
@@ -38,7 +38,7 @@ ei_containers_lib.make_all(1, "green", 48, 2, false, {
     {"advanced-circuit", 1}
 })
 
-ei_containers_lib.make_all(1, "filter", 48, 2, false, {
+ei_containers_lib.make_all(1, "filter", 18, 2, false, {
     {"ei_1x1-container", 1},
     {"electronic-circuit", 1}
 })
@@ -87,7 +87,7 @@ ei_containers_lib.make_all(2, "green", 200, 2, true, {
     {"steel-plate", 5}
 })
 
-ei_containers_lib.make_all(2, "filter", 200, 2, false, {
+ei_containers_lib.make_all(2, "filter", 75, 2, false, {
     {"ei_2x2-container", 1},
     {"electronic-circuit", 10}
 })
@@ -137,7 +137,7 @@ ei_containers_lib.make_all(6, "green", 1000, 2, true, {
     {"steel-plate", 10}
 })
 
-ei_containers_lib.make_all(6, "filter", 1000, 2, false, {
+ei_containers_lib.make_all(6, "filter", 375, 2, false, {
     {"ei_6x6-container", 1},
     {"electronic-circuit", 20}
 })


### PR DESCRIPTION
Adjusts stack size for larger containers to be in line with smallest container.

Stack sizes for larger containers are 37.5% of unfiltered version, in line with smallest having 18 slots instead of 48 for filtered version.